### PR TITLE
On clicking spacebar, dropdown is destroyed

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -85,7 +85,7 @@
 </div>
 
 <script type="module">
-	import { floatype } from './floatype.min.js';
+	import { floatype } from '../floatype.js';
 
 	document.querySelector("textarea").value = "";
 

--- a/floatype.js
+++ b/floatype.js
@@ -44,12 +44,12 @@ export function floatype(el, options = {}) {
 			case 38: return navigate(-1, e); // Up arrow.
 			case 40: return navigate(1, e); // Down arrow
 			case 9: // Tab
-			case 32: // Space
 			case 13: // Enter
 				e.preventDefault();
 				select(cur);
 				destroy();
 				return;
+			case 32: // Space
 			case 27: // Escape.
 				destroy(); 
 				return true;


### PR DESCRIPTION
After typing a word if the user presses spacebar, the first option in the dropdown gets selected. As I was using the textArea I found it annoying and I had to go back and delete the previous word.

The user intention of pressing the spacebar would be after completing the word and has neglected the current suggestions from dorpdown.


https://github.com/user-attachments/assets/bb1b9019-b311-424b-9523-1ed1e1ff2917

Ref: #8 