### PR TITLE
[bug fix] Dropdown select box does not change position on scroll

### DIFF
--- a/floatype.js
+++ b/floatype.js
@@ -85,14 +85,17 @@ export function floatype(el, options = {}) {
 
 		box.classList.add("floatype");
 		el.parentNode.insertBefore(box, el.nextSibling);
+		window.addEventListener("scroll", adjustBoxPosition);
 	}
-
+	function adjustBoxPosition(){
+		const coords = getCaret(el);
+    	box.style.left = `${coords.x}px`;
+    	box.style.top = `${coords.y}px`;
+	}
 	function renderResults() {
 		box.innerHTML = "";
 
-		const coords = getCaret(el);
-		box.style.left = `${coords.x}px`;
-		box.style.top = `${coords.y}px`;
+		adjustBoxPosition()
 
 		items.forEach((item, idx) => {
 			const div = document.createElement("div");
@@ -134,6 +137,7 @@ export function floatype(el, options = {}) {
 		if (box) {
 			box.remove();
 			box = null;
+			window.removeEventListener("scroll", adjustBoxPosition);
 		}
 	}
 


### PR DESCRIPTION
Hi @knadh ,
This is a small PR to fix the issue where the box does not change its position based on scroll. Basically we had to recalculate the carat position on scroll.

before ( Notice , when I scroll the box stays as it is which isn't ideal UX)

https://github.com/user-attachments/assets/07b58622-260d-4e5a-a90c-5c01fa51dab6


now after fix:

https://github.com/user-attachments/assets/4780daca-f5b0-44d1-8533-9df936b4668e

